### PR TITLE
Fix: Adjust top meta bar layout and revert series categories

### DIFF
--- a/style.css
+++ b/style.css
@@ -439,9 +439,9 @@ body.single .gp-top-meta-bar,
     width: 100% !important;
     min-height: 42px; /* Or original height */
     position: relative !important;
-    padding: 0 15px !important; /* Keep padding if it was there before grid */
+    padding: 0 !important; /* Removed horizontal padding */
     box-sizing: border-box !important;
-    gap: 0; /* Remove grid gap, flex gap might be different or not used */
+    /* gap: 0; /* Flex gap not needed when using space-between for outer elements */
 }
 
 /*
@@ -1947,9 +1947,9 @@ html.dark-mode-active-loading body {
     padding: 0 !important;
 }
 
-/* Adjust vertical position for single posts to be slightly higher */
+/* Adjust vertical position for single posts */
 body.single .gp-top-meta-bar-container {
-    margin: -10px 0 15px 0 !important; /* -10px top, 0 right, 15px bottom, 0 left */
+    margin: 0 0 15px 0 !important; /* 0 top, 0 right, 15px bottom, 0 left */
 }
 
 .gp-top-meta-bar {


### PR DESCRIPTION
This commit includes several adjustments based on your feedback:

1.  **Top Meta Bar on Single Posts (`body.single .gp-top-meta-bar`):**
    - Reverted layout to Flexbox with `justify-content: space-between`.
    - Main breadcrumbs (`.gp-post-category`) are centered using `position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%);`.
    - Container (`.gp-top-meta-bar-container`) vertical margin adjusted to `margin: 0 0 15px 0 !important;` to correctly position the bar.
    - Horizontal padding on `.gp-top-meta-bar` removed to allow `.left-buttons` and `.gp-language-switcher` (with `margin-left: auto`) to align with the container edges.

2.  **Language Switcher Dropdown Arrow (`style.css`):**
    - Updated the `span.dropdown-icon` within the language switcher button to use a modern SVG chevron that inherits text color and rotates when the dropdown is active.

3.  **"Series Posts" Section Category Links (`functions.php`, `style.css`):**
    - Reverted changes that added category links to items in the "Series Posts" section. These items now only display title and meta, restoring their previous layout. Corresponding CSS for these category links was removed.

These changes aim to restore the preferred visual layout of the top meta bar on single posts and address issues in the "Series Posts" section. Further refinements for language switcher dropdown items and reading time calculation will follow.